### PR TITLE
Feature: XmlPropertyManager Rework and Fixes

### DIFF
--- a/include/polymorph/engine/api.hpp
+++ b/include/polymorph/engine/api.hpp
@@ -15,6 +15,7 @@
 #include "polymorph/engine/api/plugin/PluginManager.hpp"
 #include "polymorph/engine/api/plugin/Symbols.hpp"
 #include "polymorph/engine/api/plugin/APluginConfig.hpp"
+#include "polymorph/engine/api/plugin/APluginConfig_templated.hpp"
 
 #include "polymorph/engine/api/scripting/AConfigurableSerializableObject.hpp"
 #include "polymorph/engine/api/scripting/ASerializableObject.hpp"

--- a/include/polymorph/engine/api/plugin/APluginConfig.hpp
+++ b/include/polymorph/engine/api/plugin/APluginConfig.hpp
@@ -10,7 +10,7 @@
 
 
 #include "myxmlpp/Doc.hpp"
-#include "polymorph/engine/config/XmlPluginConfig.hpp"
+#include "polymorph/engine/debug/Logger.hpp"
 
 namespace polymorph::engine {
     class Engine;
@@ -20,6 +20,9 @@ namespace polymorph::engine {
     }
     namespace time {
         class Time;
+    }
+    namespace config {
+        class XmlPluginConfig;
     }
 }
 namespace polymorph::engine::api
@@ -92,48 +95,13 @@ namespace polymorph::engine::api
              * @param value The value of the property
              */
             template<typename T>
-            void saveProperty(std::string propertyName, T &toSave)
-            {
-                manager->XmlPropertyManager::save(propertyName, toSave);
-            }
+            void saveProperty(std::string propertyName, T &toSave);
 
-            /**
-             * @brief Saves a property in the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The value of the property
-             */
-            template<typename T>
-            void saveProperty(std::string propertyName, std::shared_ptr<T> &toSave)
-            {
-                manager->save(propertyName, toSave);
-            }
 
-            /**
-             * @brief Saves a property in the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The value of the property
-             */
-            template<typename T>
-            void saveProperty(std::string propertyName, safe_ptr<T> &toSave)
-            {
-                manager->save(propertyName, toSave);
-            }
+
 
 
         protected:
-            /**
-             * @brief Sets a property from the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The property to set
-             */
-            template<typename T>
-            void _setProperty(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                manager->set(propertyName, toSet, level);
-            }
 
             /**
              * @brief Sets a property from the Xml data by its name
@@ -142,22 +110,7 @@ namespace polymorph::engine::api
              * @param value The property to set
              */
             template<typename T>
-            void _setProperty(const std::string &propertyName, safe_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                manager->set(propertyName, toSet, level);
-            }
-
-            /**
-             * @brief Sets a property from the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The property to set
-             */
-            template<typename T>
-            void _setProperty(const std::string &propertyName, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                manager->XmlPropertyManager::set(propertyName, toSet, level);
-            }
+            void _setProperty(const std::string &propertyName, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG);
 //////////////////////--------------------------/////////////////////////
     };
 

--- a/include/polymorph/engine/api/plugin/APluginConfig_templated.hpp
+++ b/include/polymorph/engine/api/plugin/APluginConfig_templated.hpp
@@ -1,0 +1,29 @@
+/*
+** EPITECH PROJECT, 2020
+** APluginConfig_templated.hpp
+** File description:
+** header for APluginConfig_templated.c
+*/
+
+
+#pragma once
+#include "APluginConfig.hpp"
+#include "polymorph/engine/config/XmlPluginConfig.hpp"
+
+
+namespace polymorph::engine::api
+{
+    template<typename T>
+    void APluginConfig::saveProperty(std::string name, T &value)
+    {
+        manager->save(name, value);
+    }    
+    
+    template<typename T>
+    void APluginConfig::_setProperty(const std::string &propertyName, T &toSet,
+                                      debug::Logger::severity level)
+    {
+        manager->save(propertyName, toSet, level);
+    }
+
+}

--- a/include/polymorph/engine/api/scripting/ASerializableObject.hpp
+++ b/include/polymorph/engine/api/scripting/ASerializableObject.hpp
@@ -108,58 +108,11 @@ namespace polymorph::engine::api
             template<typename T>
             void saveProperty(std::string propertyName, T &toSave)
             {
-                manager->XmlPropertyManager::save(propertyName, toSave);
-            }
-
-            /**
-             * @brief Saves a property in the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The value of the property
-             */
-            template<typename T>
-            void saveProperty(std::string propertyName, std::shared_ptr<T> &toSave)
-            {
                 manager->save(propertyName, toSave);
             }
 
-            /**
-             * @brief Saves a property in the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The value of the property
-             */
-            template<typename T>
-            void saveProperty(std::string propertyName, safe_ptr<T> &toSave)
-            {
-                manager->save(propertyName, toSave);
-            }
 
         protected:
-            /**
-             * @brief Sets a property from the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The property to set
-             */
-            template<typename T>
-            void _setProperty(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                manager->set(propertyName, toSet, level);
-            }
-
-            /**
-             * @brief Sets a property from the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The property to set
-             */
-            template<typename T>
-            void _setProperty(const std::string &propertyName, safe_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                manager->set(propertyName, toSet, level);
-            }
-
             /**
              * @brief Sets a property from the Xml data by its name
              * @param name The name of the property

--- a/include/polymorph/engine/config/XmlPluginConfig.hpp
+++ b/include/polymorph/engine/config/XmlPluginConfig.hpp
@@ -8,10 +8,7 @@
 
 #pragma once
 
-
-#include "XmlPropertyManager.hpp"
-#include "polymorph/engine/core/Engine.hpp"
-#include "polymorph/engine/api/plugin/PluginManager.hpp"
+#include "polymorph/engine/config/XmlPropertyManager.hpp"
 
 namespace polymorph::engine {
     class Engine;
@@ -35,24 +32,6 @@ namespace polymorph::engine::config
 
             void saveConfig(std::string filePath = "");
 
-            template<typename T>
-            void set(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                _setSerializableProperty<T>(property, toSet, level);
-            };
-
-            template<typename T>
-            void save(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                static_assert(!CastHelper::is_map<T>);
-                toSet->saveAll();
-            };
-
         private:
             std::string _type;
             std::shared_ptr<myxmlpp::Doc> _doc;
@@ -65,7 +44,16 @@ namespace polymorph::engine::config
 /////////////////////////////// METHODS /////////////////////////////////
         public:
             std::string getType();
+            
+            template<typename T>
+            void set(std::string property, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG) {
+                this->XmlPropertyManager::set(property, toSet, _engine, _type, level);
+            }
 
+            template<typename T>
+            void save(std::string property, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG) {
+                this->XmlPropertyManager::save(property, toSet, level);
+            }
         protected:
             void _onWrongValueExcept(debug::Logger::severity level,
                                      std::string propertyName,
@@ -90,62 +78,7 @@ namespace polymorph::engine::config
              */
             void _logWrongValue(std::string type, std::string name, debug::Logger::severity level);
 
-            template<typename T, typename T2 = void>
-            void _setSerializableProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                    std::shared_ptr<T> &toSet,
-                                    debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-
-                //TODO: rework with new XmlSeralizableObject
-                static_assert(!CastHelper::is_map<T>
-                              && !CastHelper::is_vector<T>
-                              && !CastHelper::is_safeptr<T>
-                              && !std::is_enum<T>());
-                if constexpr (CastHelper::is_builtin<T>)
-                    return std::make_shared<T>(data, *this);
-                else {
-                    auto t = data->findAttribute("subtype")->getValue();
-                    try {
-                        toSet = std::dynamic_pointer_cast<T>(_engine.getPluginManager().tryCreateConfigObject(t, data, _engine.getPluginManager().getConfig(_type)));
-                    }  catch (debug::ExceptionLogger &e) {
-                        if (level != debug::Logger::MAJOR)
-                            e.what();
-                    }
-                }
-            };
-
-
-            template<typename T>
-            void _setSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::shared_ptr<T> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _setSerializableProperty<T>(property, toSet, level);
-            };
-
-
-            template<typename T>
-            void _saveSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::shared_ptr<T> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                toSet->saveAll();
-            };
-//////////////////////--------------------------/////////////////////////
+ //////////////////////--------------------------/////////////////////////
 
     };
 

--- a/include/polymorph/engine/config/XmlPropertyManager.hpp
+++ b/include/polymorph/engine/config/XmlPropertyManager.hpp
@@ -15,6 +15,13 @@
 
 #include "myxmlpp/myxmlpp.hpp"
 
+#include "polymorph/engine/core/Engine.hpp"
+#include "polymorph/engine/core/entity/Entity.hpp"
+#include "polymorph/engine/core/component/AComponent.hpp"
+
+#include "polymorph/engine/api/SceneManager.hpp"
+#include "polymorph/engine/api/plugin/APluginConfig.hpp"
+
 #include "polymorph/engine/debug/Logger.hpp"
 #include "polymorph/engine/config/CastHelper.hpp"
 #include "polymorph/engine/types/safe/safe_ptr.hpp"
@@ -62,181 +69,193 @@ namespace polymorph::engine::config
 
 /////////////////////////////// METHODS /////////////////////////////////
         public:
-            /**
-             * @brief Extract a PRIMITIVE property from the xml node
-             *
-             * @tparam T The type of the property
-             * @param propertyName The name of the property
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             *
-            template<typename T> requires (!CastHelper::is_builtin<T>)
-            void set(const std::string &propertyName, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                if constexpr (std::is_enum<T>())
-                    _setBuiltinProperty(property, reinterpret_cast<int &>(toSet), level);
-                else if constexpr (!std::is_enum<T>())
-                    _setBuiltinProperty(property, toSet, level);
-            };*/
-
-            /**
-             * @brief Extract a VECTOR property from the xml node
-             *
-             * @tparam T The type of the property
-             * @param propertyName The name of the property
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-
-            template<typename T>
-            void set(const std::string &propertyName, std::vector<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                _setVectorProperty(property, toSet, level);
-            };
-
-            /**
-             * @brief Extract a MAP property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void set(const std::string &propertyName, std::map<T1, T2> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _setMapProperty<T1, T2>(property, toSet, level);
-            };
-
-            /**
-             * @brief Extract an UNORDERED MAP property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void set(const std::string &propertyName, std::unordered_map<T1, T2> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _setUMapProperty<T1, T2>(property, toSet, level);
-            };
-
-
-
-
-            /**
-             * @brief Extract a PRIMITIVE property from the xml node
-             *
-             * @tparam T The type of the property
-             * @param propertyName The name of the property
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T>
-            void save(const std::string &propertyName, T &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                if constexpr (std::is_enum<T>())
-                    _savePrimitiveProperty<int>(property, reinterpret_cast<int &>(toSave), level);
-                else if constexpr (!std::is_enum<T>())
-                    _savePrimitiveProperty<T>(property, toSave, level);
-            };
-
-            /**
-             * @brief Extract a VECTOR property from the xml node
-             *
-             * @tparam T The type of the property
-             * @param propertyName The name of the property
-             * @param toSave The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-
-            template<typename T>
-            void save(const std::string &propertyName, std::vector<T> &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                _saveVectorProperty(property, toSave, level);
-            };
-
-            /**
-             * @brief Extract a MAP property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param toSave The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void save(const std::string &propertyName, std::map<T1, T2> &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _saveMapProperty<T1, T2>(property, toSave, level);
-            };
-
-            /**
-             * @brief Extract an UNORDERED MAP property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param toSave The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void save(const std::string &propertyName, std::unordered_map<T1, T2> &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _saveUMapProperty<T1, T2>(property, toSave, level);
-            };
 
             std::shared_ptr<myxmlpp::Node> getNode();
 
 
 
 
+            
+            
+            
+            
 
 
 
-        protected:
-            /* ***********************************************
-             * @group Set Sub Property specializations
-             * ***********************************************/
+
+
+// section PRIMITIVE/BUILTIN
+            /**
+             * @brief Extract a PRIMITIVE property from the xml node
+             *
+             * @tparam T The type of the property
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T, typename T2 = void>
+            void set(const std::string &propertyName, T &toSet, Engine &entity, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, entity.getPluginManager().getConfig(type), level);
+            };
+            
+            /**
+             * @brief Extract a PRIMITIVE property from the xml node
+             *
+             * @tparam T The type of the property
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T, typename T2 = void>
+            void set(const std::string &propertyName, T &toSet, safe_ptr<api::APluginConfig> config, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, config, level);
+            };
+            
+            /**
+             * @brief Extract a PRIMITIVE property from the xml node
+             *
+             * @tparam T The type of the property
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T, typename T2 = void>
+            void set(const std::string &propertyName, T &toSet, safe_ptr<AComponent> config, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, config, level);
+            };
+            
+            template<typename T, typename T2 = void>
+            void set(const std::string &propertyName, T &toSet, GameObject entity, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, entity, type, level);
+            };
+
+
+            /**
+             * @brief Set Property INT Specialization
+             */
+            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                       int &toSet, debug::Logger::severity level)
+            {
+                _setPropertyFromAttr(toSet, data, level);
+            }
+
+            /**
+             * @brief Set Property FLOAT Specialization
+             */
+            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                       float &toSet, debug::Logger::severity level)
+            {
+                _setPropertyFromAttr(toSet, data, level);
+            }
+
+            /**
+             * @brief Set Property BOOL Specialization
+             */
+            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                       bool &toSet, debug::Logger::severity level)
+            {
+                _setPropertyFromAttr(toSet, data, level);
+            }
+
+            /**
+             * @brief Set Property STRING Specialization
+             */
+            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                       std::string &toSet,
+                                       debug::Logger::severity level)
+            {
+                _setPropertyFromAttr(toSet, data, level);
+            }
+
+            /**
+ * @brief Set Property BUILTIN Specialization
+ */
+            template<typename T, typename T2 = void>
+            void _setBuiltinProperty(std::shared_ptr<myxmlpp::Node> &data, T &toSet, safe_ptr<api::APluginConfig> _config,
+                                     debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>()
+                              && CastHelper::is_builtin<T>);
+                toSet = T(_config, data);
+            };
+
+            /**
+             * @brief Set Property BUILTIN Specialization
+             */
+            template<typename T, typename T2 = void>
+            void _setBuiltinProperty(std::shared_ptr<myxmlpp::Node> &data, T &toSet, safe_ptr<AComponent> _component,
+                                     debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>()
+                              && CastHelper::is_builtin<T>);
+                toSet = T(_component, data);
+            };
+            
+            /**
+ * @brief Set Property BUILTIN Specialization
+ */
+            template<typename T, typename T2 = void> requires CastHelper::is_builtin<T>
+            void _setBuiltinProperty(std::shared_ptr<myxmlpp::Node> &data, T &toSet,
+                                     GameObject entity, std::string _type,
+                                     debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>()
+                              && CastHelper::is_builtin<T>);
+                toSet = T(entity->getComponent(_type), data);
+            };
 
 
             /**
@@ -251,10 +270,10 @@ namespace polymorph::engine::config
             template<typename T>
             void _setSubProperty(const std::string &propertyName,
                                  const std::shared_ptr<myxmlpp::Node> &data,
-                                 T &toSet,
+                                 T &toSet, GameObject entity, std::string type,
                                  debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
                                                           ? _findProperty(propertyName, data)
                                                           : data;
 
@@ -263,13 +282,13 @@ namespace polymorph::engine::config
                 static_assert(!CastHelper::is_map<T>);
                 if constexpr (std::is_enum<T>())
                     _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
-                else if constexpr (!std::is_enum<T>())
-                    _setPrimitiveProperty<T>(property, toSet, level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, entity, type, level);
             };
-
-
             /**
-             * @brief Extract an VECTOR SUB-property from the xml node
+             * @brief Extract an PRIMITIVE SUB-property from the xml node
              *
              * @tparam T The type of the property
              * @param propertyName The name of the property
@@ -280,83 +299,10 @@ namespace polymorph::engine::config
             template<typename T>
             void _setSubProperty(const std::string &propertyName,
                                  const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::vector<T> &toSet,
+                                 T &toSet, Engine &entity, std::string type,
                                  debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                _setVectorProperty<T>(property, toSet, level);
-            };
-
-
-            /**
-             * @brief Extract an MAP SUB-property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param data The node to search the sub-property in
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void _setSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::map<T1, T2> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _setMapProperty<T1, T2>(property, toSet, level);
-            };
-
-            /**
-             * @brief Extract an UNORDERED MAP SUB-property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param data The node to search the sub-property in
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void _setSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::unordered_map<T1, T2> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _setUMapProperty<T1, T2>(property, toSet, level);
-            };
-
-
-
-
-
-
-
-            template<typename T>
-            void _saveSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 T &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
                                                           ? _findProperty(propertyName, data)
                                                           : data;
 
@@ -364,228 +310,84 @@ namespace polymorph::engine::config
                     _onMissingPropertyExcept(level, propertyName);
                 static_assert(!CastHelper::is_map<T>);
                 if constexpr (std::is_enum<T>())
-                    _savePrimitiveProperty<int>(property, reinterpret_cast<int &>(toSet), level);
-                else if constexpr (!std::is_enum<T>())
-                    _savePrimitiveProperty<T>(property, toSet, level);
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, entity, type, level);
             };
-
-
-            /**
-             * @brief Extract an VECTOR SUB-property from the xml node
-             *
-             * @tparam T The type of the property
-             * @param propertyName The name of the property
-             * @param data The node to search the sub-property in
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
+            
             template<typename T>
-            void _saveSubProperty(const std::string &propertyName,
+            void _setSubProperty(const std::string &propertyName,
                                  const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::vector<T> &toSet,
+                                 T &toSet, safe_ptr<AComponent> component,
                                  debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
                                                           ? _findProperty(propertyName, data)
                                                           : data;
 
                 if (property == nullptr)
                     _onMissingPropertyExcept(level, propertyName);
                 static_assert(!CastHelper::is_map<T>);
-                _saveVectorProperty<T>(property, toSet, level);
+                if constexpr (std::is_enum<T>())
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, component, level);
             };
 
-
-            /**
-             * @brief Extract an MAP SUB-property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param data The node to search the sub-property in
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void _saveSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::map<T1, T2> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _saveMapProperty<T1, T2>(property, toSet, level);
-            };
-
-            /**
-             * @brief Extract an UNORDERED MAP SUB-property from the xml node
-             *
-             * @tparam T1 The type of the Key
-             * @tparam T2 The type of the Value
-             * @param propertyName The name of the property
-             * @param data The node to search the sub-property in
-             * @param toSet The property to set
-             * @param level The level of the error if something goes wrong (not found or wrong value)
-             */
-            template<typename T1, typename T2>
-            void _saveSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::unordered_map<T1, T2> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _saveUMapProperty<T1, T2>(property, toSet, level);
-            };
-
-
-
-
-
-
-
-
-
-
-            /* ***********************************************
-             * @group Set Property Specializations
-             * ***********************************************/
-
-
-
-
-            /**
-             * @brief Set Property INT Specialization
-             */
-            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       int &toSet, debug::Logger::severity level)
-            {
-                _setPropertyFromAttr(toSet, data, level);
-            }
-
-            /**
-             * @brief Set Property FLOAT Specialization
-             */
-            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       float &toSet, debug::Logger::severity level)
-            {
-                _setPropertyFromAttr(toSet, data, level);
-            }
-
-            /**
-             * @brief Set Property BOOL Specialization
-             */
-            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       bool &toSet, debug::Logger::severity level)
-            {
-                _setPropertyFromAttr(toSet, data, level);
-            }
-
-            /**
-             * @brief Set Property STRING Specialization
-             */
-            void _setPrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       std::string &toSet,
-                                       debug::Logger::severity level)
-            {
-                _setPropertyFromAttr(toSet, data, level);
-            }
-
-
-            /**
-             * @brief Set Property VECTOR Specialization
-             */
             template<typename T>
-            void _setVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                    std::vector<T> &toSet,
-                                    debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                for (auto &elem: *data)
-                {
-                    T tmp;
-
-                    _setSubProperty("", elem, tmp, level);
-                    toSet.push_back(tmp);
-                }
-            };
-
-            /**
-             * @brief Set Property MAP Specialization
-             */
-            template<typename T1, typename T2>
-            void _setMapProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                 std::map<T1, T2> &toSet,
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 T &toSet, safe_ptr<api::APluginConfig> config,
                                  debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                for (auto &elem: *data)
-                {
-                    T1 key;
-                    auto keyElem = elem->begin();
-                    T2 value;
-                    auto valueElem = elem->begin() + 1;
-                    _setSubProperty("", *keyElem, key, level);
-                    _setSubProperty("", *valueElem, value, level);
-                    toSet.insert_or_assign(key, value);
-                }
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>())
+                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
+                    _setPrimitiveProperty(property, toSet, level);
+                else if constexpr (CastHelper::is_builtin<T>)
+                    _setBuiltinProperty(property, toSet, config, level);
             };
+
 
             /**
-             * @brief Set Property UNORDERED MAP Specialization
-             */
-            template<typename T1, typename T2>
-            void _setUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                  std::unordered_map<T1, T2> &toSet,
-                                  debug::Logger::severity level = debug::Logger::DEBUG)
+ * @brief Extract a PRIMITIVE property from the xml node
+ *
+ * @tparam T The type of the property
+ * @param propertyName The name of the property
+ * @param toSet The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T>
+            void save(const std::string &propertyName, T &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                for (auto &elem: *data)
-                {
-                    T1 key;
-                    auto keyElem = elem->begin();
-                    auto valueElem = elem->begin() + 1;
-                    T2 value;
-                    _setSubProperty("", *keyElem, key, level);
-                    _setSubProperty("", *valueElem, value, level);
-                    toSet.emplace(key, value);
-                }
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>())
+                    _savePrimitiveProperty<int>(property, reinterpret_cast<int &>(toSave), level);
+                else if constexpr (!std::is_enum<T>())
+                    _savePrimitiveProperty(property, toSave, level);
             };
 
-            /**
-             * @brief Set Property MAP from node Specialization
-             */
-            template<typename T0, typename T1, typename T2>
-            void _setMapPropertyFromNode(std::shared_ptr<myxmlpp::Node> &data,
-                                         std::map<T1, T2> &toSet,
-                                         debug::Logger::severity level = debug::Logger::DEBUG)
+            template<typename T, typename T2 = void>
+            void _savePrimitiveProperty(std::shared_ptr<myxmlpp::Node> &_, T &toSet,
+                                        debug::Logger::severity _2 = debug::Logger::DEBUG)
             {
-                static_assert(std::is_same<T0, typename std::map<T1, T2>>::value);
-                _setMapProperty(data, toSet, level);
-            };
-
-            /**
-             * @brief Set Property UNORDERED MAP from node Specialization
-             */
-            template<typename T0, typename T1, typename T2>
-            void _setMapPropertyFromNode(std::shared_ptr<myxmlpp::Node> &data,
-                                         std::unordered_map<T1, T2> &toSet,
-                                         debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                static_assert(std::is_same<T0, typename std::unordered_map<T1, T2>>::value);
-                _setUMapProperty(data, toSet, level);
-            };
-
-
-                  template<typename T, typename T2 = void>
-            void _savePrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data, T &toSet,
-                                       debug::Logger::severity level = debug::Logger::DEBUG)
-            {
+                (void)_; 
+                (void)_2;
                 static_assert(!CastHelper::is_map<T>
                               && !CastHelper::is_vector<T>
                               && !CastHelper::is_safeptr<T>
@@ -599,7 +401,7 @@ namespace polymorph::engine::config
              */
             template<typename T2 = void>
             void _savePrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       int &toSet, debug::Logger::severity level)
+                                        int &toSet, debug::Logger::severity level)
             {
                 _savePropertyFromAttr(toSet, data, level);
             }
@@ -609,7 +411,7 @@ namespace polymorph::engine::config
              */
             template<typename T2 = void>
             void _savePrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       float &toSet, debug::Logger::severity level)
+                                        float &toSet, debug::Logger::severity level)
             {
                 _savePropertyFromAttr(toSet, data, level);
             }
@@ -619,7 +421,7 @@ namespace polymorph::engine::config
              */
             template<typename T2 = void>
             void _savePrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       bool &toSet, debug::Logger::severity level)
+                                        bool &toSet, debug::Logger::severity level)
             {
                 _savePropertyFromAttr(toSet, data, level);
             }
@@ -629,20 +431,725 @@ namespace polymorph::engine::config
              */
             template<typename T2 = void>
             void _savePrimitiveProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                       std::string &toSet,
-                                       debug::Logger::severity level)
+                                        std::string &toSet,
+                                        debug::Logger::severity level)
             {
                 _savePropertyFromAttr(toSet, data, level);
             }
 
 
+            template<typename T>
+            void _saveSubProperty(const std::string &propertyName,
+                                  const std::shared_ptr<myxmlpp::Node> &data,
+                                  T &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>())
+                    _savePrimitiveProperty<int>(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>())
+                    _savePrimitiveProperty<T>(property, toSet, level);
+            };
+            
+///////////////////////////// XML PRIMITIVE AND BUILTIN SETTERS END //////////////////////////////
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// section REFERENCES
+
+            template<typename T>
+            void set(const std::string &propertyName, safe_ptr<T> &toSet, GameObject entity, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setRefProperty<T>(property, toSet, entity, level);
+            };
+
+            template<typename T>
+            void set(const std::string &propertyName, safe_ptr<T> &toSet, safe_ptr<AComponent> component, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setRefProperty<T>(property, toSet, component, level);
+            };
+
+
+
+            template<typename T, typename T2 = void>
+            void _setRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
+                                 safe_ptr<T> &toSet, GameObject entity,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::string id;
+                std::string name = refProp->findAttribute("name")->getValue();
+                GameObject gameObject;
+
+                if (!_setPropertyFromAttr(id, refProp, level))
+                    return;
+                if (entity && (entity->getPrefabId() == id || entity->getId() == id))
+                    gameObject = entity;
+                if (!gameObject && entity->wasPrefab())
+                    gameObject = entity->findByPrefabId(id);
+                else if (!gameObject)
+                    gameObject = entity->Scene.findById(id);
+                if (gameObject)
+                    toSet = gameObject->getComponent<T>();
+                if (!toSet)
+                    _onWrongValueExcept(level, name, id);
+            };
+
+            template<typename T2 = void>
+            void _setRefProperty(std::shared_ptr<myxmlpp::Node> &refProp, GameObject &toSet,
+                                 GameObject &entity, debug::Logger::severity level)
+            {
+                std::string id;
+                std::string name = refProp->findAttribute("name")->getValue();
+
+                if (!_setPropertyFromAttr(id, refProp, level))
+                    return;
+                if (entity && (entity->getPrefabId() == id || entity->getId() == id))
+                    toSet = entity;
+                if (!toSet && entity)
+                    toSet = entity->findByPrefabId(id);
+                if (!toSet)
+                    toSet = entity->Scene.findById(id);
+                if (!toSet)
+                    _onWrongValueExcept(level, name, id);
+            };
+            template<typename T, typename T2 = void>
+            void _setRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
+                                 safe_ptr<T> &toSet, safe_ptr<AComponent> _component,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::string id;
+                std::string name = refProp->findAttribute("name")->getValue();
+                GameObject gameObject;
+
+                if (!_setPropertyFromAttr(id, refProp, level))
+                    return;
+                if (_component && (_component->gameObject->getPrefabId() == id || _component->gameObject->getId() == id))
+                    gameObject = _component->gameObject;
+                if (!gameObject && _component->gameObject->wasPrefab())
+                    gameObject = _component->gameObject->findByPrefabId(id);
+                else if (!gameObject)
+                    gameObject = _component->Scene.findById(id);
+                if (gameObject)
+                    toSet = gameObject->getComponent<T>();
+                if (!toSet)
+                    _onWrongValueExcept(level, name, id);
+            };
+
+            template<typename T2 = void>
+            void _setRefProperty(std::shared_ptr<myxmlpp::Node> &refProp, GameObject &toSet,
+                                 safe_ptr<AComponent> _component, debug::Logger::severity level)
+            {
+                std::string id;
+                std::string name = refProp->findAttribute("name")->getValue();
+
+                if (!_setPropertyFromAttr(id, refProp, level))
+                    return;
+                if (_component && (_component->gameObject->getPrefabId() == id || _component->gameObject->getId() == id))
+                    toSet = _component->gameObject;
+                if (!toSet && _component->gameObject)
+                    toSet = _component->gameObject->findByPrefabId(id);
+                if (!toSet)
+                    toSet = _component->Scene.findById(id);
+                if (!toSet)
+                    _onWrongValueExcept(level, name, id);
+            };
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 safe_ptr<T> &toSet, safe_ptr<AComponent> _component,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setRefProperty(property, toSet, _component, level);
+            };
+            
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 safe_ptr<T> &toSet, GameObject entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setRefProperty(property, toSet, entity, level);
+            };
+
+            
+            template<typename T>
+            void save(const std::string &propertyName, safe_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _saveRefProperty(property, toSet, level);
+            };
+
+            template<typename T, typename T2 = void>
+            void _saveRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
+                                  safe_ptr<T> &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::string id = (toSet) ? toSet->gameObject->getId() : "";
+
+                if (!_savePropertyFromAttr(id, refProp, level))
+                    return;
+            };
+
+            template<typename T2 = void>
+            void _saveRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
+                                  GameObject &toSet, debug::Logger::severity level)
+            {
+                std::string id = (toSet) ? toSet->getId() : "";
+
+                if (!_savePropertyFromAttr(id, refProp, level))
+                    return;
+            };
+
+            template<typename T>
+            void _saveSubProperty(const std::string &propertyName,
+                                  const std::shared_ptr<myxmlpp::Node> &data,
+                                  safe_ptr<T> &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                if constexpr (std::is_enum<T>())
+                    _savePrimitiveProperty<int>(property, reinterpret_cast<int &>(toSet), level);
+                else if constexpr (!std::is_enum<T>())
+                    _saveRefProperty<T>(property, toSet, level);
+            };
+
+//////////////////////// XML REFERENCE SETTERS END ////////////////////////
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// section SERIALIZABLES
+            template<typename T>
+            void set(const std::string &propertyName, std::shared_ptr<T> &toSet, GameObject entity, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setSerializableProperty(property, toSet, entity, type, level);
+            };
+            
+            template<typename T>
+            void set(const std::string &propertyName, std::shared_ptr<T> &toSet, safe_ptr<AComponent> component, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setSerializableProperty(property, toSet, component, level);
+            };
+            
+            template<typename T>
+            void set(const std::string &propertyName, std::shared_ptr<T> &toSet, safe_ptr<api::APluginConfig> config, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setSerializableProperty(property, toSet, config, level);
+            };
+            
+            template<typename T>
+            void set(const std::string &propertyName, std::shared_ptr<T> &toSet, Engine &engine, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setSerializableProperty(property, toSet, engine, type, level);
+            };
+
+
+
+            template<typename T, typename T2 = void>
+            void _setSerializableProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                          std::shared_ptr<T> &toSet, GameObject entity, std::string _type,
+                                          debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>());
+                if constexpr (CastHelper::is_builtin<T>)
+                    return std::make_shared<T>(data, *this);
+                else {
+                    auto t = data->findAttribute("subtype")->getValue();
+                    try {
+                        toSet = std::dynamic_pointer_cast<T>(entity->Plugin.tryCreateComponentObject(t, data, entity->getComponent(_type)));
+                    }  catch (debug::ExceptionLogger &e) {
+                        if (level != debug::Logger::MAJOR)
+                            e.what();
+                    }
+                }
+            };
+
+            template<typename T, typename T2 = void>
+            void _setSerializableProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                          std::shared_ptr<T> &toSet, safe_ptr<AComponent> _component,
+                                          debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+
+                //TODO: rework with new XmlSeralizableObject
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>());
+                if constexpr (CastHelper::is_builtin<T>)
+                    return std::make_shared<T>(data, *this);
+                else {
+                    auto t = data->findAttribute("subtype")->getValue();
+                    try {
+                        toSet = std::dynamic_pointer_cast<T>(_component->Plugin.tryCreateComponentObject(t, data, _component));
+                    }  catch (debug::ExceptionLogger &e) {
+                        if (level == debug::Logger::MAJOR)
+                            e.what();
+                    }
+                }
+            };
+
+            template<typename T, typename T2 = void>
+            void _setSerializableProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                          std::shared_ptr<T> &toSet, safe_ptr<api::APluginConfig> _config,
+                                          debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>());
+                if constexpr (CastHelper::is_builtin<T>)
+                    return std::make_shared<T>(data, *this);
+                else {
+                    auto t = data->findAttribute("subtype")->getValue();
+                    try {
+                        toSet = std::dynamic_pointer_cast<T>(_config->Plugin.tryCreateConfigObject(t, data, _config));
+                    }  catch (debug::ExceptionLogger &e) {
+                        if (level == debug::Logger::MAJOR)
+                            e.what();
+                    }
+                }
+            };
+
+            template<typename T, typename T2 = void>
+            void _setSerializableProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                          std::shared_ptr<T> &toSet, Engine &_engine, std::string _type,
+                                          debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>
+                              && !CastHelper::is_vector<T>
+                              && !CastHelper::is_safeptr<T>
+                              && !std::is_enum<T>());
+                if constexpr (CastHelper::is_builtin<T>)
+                    return std::make_shared<T>(data, *this);
+                else {
+                    auto t = data->findAttribute("subtype")->getValue();
+                    try {
+                        toSet = std::dynamic_pointer_cast<T>(_engine.getPluginManager().tryCreateConfigObject(t, data, _engine.getPluginManager().getConfig(_type)));
+                    }  catch (debug::ExceptionLogger &e) {
+                        if (level != debug::Logger::MAJOR)
+                            e.what();
+                    }
+                }
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::shared_ptr<T> &toSet, Engine &_engine, std::string _type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setSerializableProperty(property, toSet, _engine, _type, level);
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::shared_ptr<T> &toSet, safe_ptr<api::APluginConfig> _config,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setSerializableProperty(property, toSet, _config, level);
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::shared_ptr<T> &toSet, safe_ptr<AComponent> _component,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setSerializableProperty(property, toSet, _component, level);
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::shared_ptr<T> &toSet, GameObject entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setSerializableProperty(property, toSet, entity, type, level);
+            };
+
+            template<typename T>
+            void save(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                static_assert(!CastHelper::is_map<T>);
+                toSet->saveAll();
+            };
+
+            template<typename T>
+            void _saveSubProperty(const std::string &propertyName,
+                                  const std::shared_ptr<myxmlpp::Node> &data,
+                                  std::shared_ptr<T> &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                toSet->saveAll();
+            };
+
+//////////////////////// XML SERIALIZABLE SETTERS END ////////////////////////
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// section VECTORS
+            /**
+             * @brief Extract a VECTOR property from the xml node
+             *
+             * @tparam T The type of the property
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+
+            template<typename T>
+            void set(const std::string &propertyName, std::vector<T> &toSet, GameObject &entity, std::string &type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setVectorProperty(property, toSet, entity, type, level);
+            };
+
+            template<typename T>
+            void set(const std::string &propertyName, std::vector<T> &toSet, safe_ptr<AComponent> component, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setVectorProperty(property, toSet, component, level);
+            };
+
+            template<typename T>
+            void set(const std::string &propertyName, std::vector<T> &toSet, safe_ptr<api::APluginConfig> config, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setVectorProperty(property, toSet, config, level);
+            };
+
+            template<typename T>
+            void set(const std::string &propertyName, std::vector<T> &toSet, Engine &engine, std::string _type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _setVectorProperty(property, toSet, engine, _type, level);
+            };
+
+            /**
+ * @brief Set Property VECTOR Specialization
+ */
+            template<typename T>
+            void _setVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                    std::vector<T> &toSet, GameObject entity, std::string type,
+                                    debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T tmp;
+
+                    _setSubProperty("", elem, tmp, entity, type, level);
+                    toSet.push_back(tmp);
+                }
+            };
             /**
              * @brief Set Property VECTOR Specialization
              */
             template<typename T>
-            void _saveVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                    std::vector<T> &toSet,
+            void _setVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                    std::vector<T> &toSet, Engine &engine, std::string type,
                                     debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T tmp;
+
+                    _setSubProperty("", elem, tmp, engine, type, level);
+                    toSet.push_back(tmp);
+                }
+            };
+            
+            /**
+             * @brief Set Property VECTOR Specialization
+             */
+            template<typename T>
+            void _setVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                    std::vector<T> &toSet, safe_ptr<AComponent> component,
+                                    debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T tmp;
+
+                    _setSubProperty("", elem, tmp, component, level);
+                    toSet.push_back(tmp);
+                }
+            };
+            
+            /**
+             * @brief Set Property VECTOR Specialization
+             */
+            template<typename T>
+            void _setVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                    std::vector<T> &toSet, safe_ptr<api::APluginConfig> config,
+                                    debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T tmp;
+
+                    _setSubProperty("", elem, tmp, config, level);
+                    toSet.push_back(tmp);
+                }
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::vector<T> &toSet, GameObject entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setVectorProperty(property, toSet, entity, type, level);
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::vector<T> &toSet, Engine &engine, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setVectorProperty(property, toSet, engine, type, level);
+            };
+            
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::vector<T> &toSet, safe_ptr<AComponent> component,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setVectorProperty(property, toSet, component, level);
+            };
+
+            template<typename T>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::vector<T> &toSet, safe_ptr<api::APluginConfig> config,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setVectorProperty(property, toSet, config, level);
+            };
+
+            /**
+ * @brief Extract a VECTOR property from the xml node
+ *
+ * @tparam T The type of the property
+ * @param propertyName The name of the property
+ * @param toSave The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T>
+            void save(const std::string &propertyName, std::vector<T> &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _saveVectorProperty(property, toSave, level);
+            };
+
+            /**
+ * @brief Set Property VECTOR Specialization
+ */
+            template<typename T>
+            void _saveVectorProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                     std::vector<T> &toSet,
+                                     debug::Logger::severity level = debug::Logger::DEBUG)
             {
                 int i = 0;
                 int countToPop = 0;
@@ -666,42 +1173,318 @@ namespace polymorph::engine::config
 
 
             /**
+ * @brief Extract an VECTOR SUB-property from the xml node
+ *
+ * @tparam T The type of the property
+ * @param propertyName The name of the property
+ * @param data The node to search the sub-property in
+ * @param toSet The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T>
+            void _saveSubProperty(const std::string &propertyName,
+                                  const std::shared_ptr<myxmlpp::Node> &data,
+                                  std::vector<T> &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                static_assert(!CastHelper::is_map<T>);
+                _saveVectorProperty<T>(property, toSet, level);
+            };
+
+//////////////////////// XML VECTOR SETTERS END ////////////////////////
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// section MAPS
+            /**
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::map<T1, T2> &toSet, GameObject entity, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, entity, type, level);
+            };
+
+            /**
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::map<T1, T2> &toSet, Engine &engine, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, engine, type, level);
+            };
+
+            /**
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::map<T1, T2> &toSet, safe_ptr<AComponent> component, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, component, level);
+            };
+
+            /**
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::map<T1, T2> &toSet, safe_ptr<api::APluginConfig> config, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, config, level);
+            };
+
+
+            /**
+             * @brief Set Property MAP Specialization
+             */
+            template<typename T1, typename T2>
+            void _setMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, GameObject entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, type, level);
+                    _setSubProperty("", *valueElem, value, entity, type, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, Engine &entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, type, level);
+                    _setSubProperty("", *valueElem, value, entity, type, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, safe_ptr<AComponent> &entity,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, level);
+                    _setSubProperty("", *valueElem, value, entity, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, safe_ptr<api::APluginConfig> &entity,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, level);
+                    _setSubProperty("", *valueElem, value, entity, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, safe_ptr<api::APluginConfig> config,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, config, level);
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, safe_ptr<AComponent> config,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, config, level);
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, GameObject config, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, config, type, level);
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::map<T1, T2> &toSet, Engine &config, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setMapProperty<T1, T2>(property, toSet, config, type, level);
+            };
+
+            /**
+ * @brief Extract a MAP property from the xml node
+ *
+ * @tparam T1 The type of the Key
+ * @tparam T2 The type of the Value
+ * @param propertyName The name of the property
+ * @param toSave The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T1, typename T2>
+            void save(const std::string &propertyName, std::map<T1, T2> &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _saveMapProperty<T1, T2>(property, toSave, level);
+            };
+
+
+
+            /**
+ * @brief Extract an MAP SUB-property from the xml node
+ *
+ * @tparam T1 The type of the Key
+ * @tparam T2 The type of the Value
+ * @param propertyName The name of the property
+ * @param data The node to search the sub-property in
+ * @param toSet The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T1, typename T2>
+            void _saveSubProperty(const std::string &propertyName,
+                                  const std::shared_ptr<myxmlpp::Node> &data,
+                                  std::map<T1, T2> &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _saveMapProperty<T1, T2>(property, toSet, level);
+            };
+
+
+            /**
              * @brief Set Property MAP Specialization
              */
             template<typename T1, typename T2>
             void _saveMapProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                 std::map<T1, T2> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                int i = 0;
-                int countToPop = 0;
-
-                std::vector<std::string> toPop;
-                std::vector<std::shared_ptr<myxmlpp::Node>> toKeep;
-                for (auto &elem: *data)
-                {
-                    if (i >= toSet.size()) {
-                        countToPop++;
-                        continue;
-                    }
-                    auto keyElem = elem->begin();
-                    auto valueElem = elem->begin() + 1;
-                    _saveSubProperty("", *keyElem, (toSet.begin() + i)->first, level);
-                    _saveSubProperty("", *valueElem, (toSet.begin() + i)->second, level);
-                }
-                toKeep.insert(toKeep.end(), data->begin(), data->begin() + i);
-                data->rmChildren();
-                for (auto &elem: toKeep)
-                    data->addChild(elem);
-
-            };
-
-            /**
-             * @brief Set Property UNORDERED MAP Specialization
-             */
-            template<typename T1, typename T2>
-            void _saveUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                  std::unordered_map<T1, T2> &toSet,
+                                  std::map<T1, T2> &toSet,
                                   debug::Logger::severity level = debug::Logger::DEBUG)
             {
                 int i = 0;
@@ -724,37 +1507,318 @@ namespace polymorph::engine::config
                 data->rmChildren();
                 for (auto &elem: toKeep)
                     data->addChild(elem);
+
+            };
+//////////////////////// XML MAP SETTERS END ////////////////////////
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// section UN_MAPS
+            /**
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::unordered_map<T1, T2> &toSet, GameObject entity, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, entity, type, level);
             };
 
             /**
-             * @brief Set Property MAP from node Specialization
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
              */
-            template<typename T0, typename T1, typename T2>
-            void _saveMapPropertyFromNode(std::shared_ptr<myxmlpp::Node> &data,
-                                         std::map<T1, T2> &toSet,
-                                         debug::Logger::severity level = debug::Logger::DEBUG)
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::unordered_map<T1, T2> &toSet, Engine &engine, std::string type, debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                static_assert(std::is_same<T0, typename std::map<T1, T2>>::value);
-                _saveMapProperty(data, toSet, level);
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, engine, type, level);
             };
 
             /**
-             * @brief Set Property UNORDERED MAP from node Specialization
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
              */
-            template<typename T0, typename T1, typename T2>
-            void _saveMapPropertyFromNode(std::shared_ptr<myxmlpp::Node> &data,
-                                         std::unordered_map<T1, T2> &toSet,
-                                         debug::Logger::severity level = debug::Logger::DEBUG)
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::unordered_map<T1, T2> &toSet, safe_ptr<AComponent> component, debug::Logger::severity level = debug::Logger::DEBUG)
             {
-                static_assert(std::is_same<T0, typename std::unordered_map<T1, T2>>::value);
-                _saveUMapProperty(data, toSet, level);
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, component, level);
+            };
+
+            /**
+             * @brief Extract a MAP property from the xml node
+             *
+             * @tparam T1 The type of the Key
+             * @tparam T2 The type of the Value
+             * @param propertyName The name of the property
+             * @param toSet The property to set
+             * @param level The level of the error if something goes wrong (not found or wrong value)
+             */
+            template<typename T1, typename T2>
+            void set(const std::string &propertyName, std::unordered_map<T1, T2> &toSet, safe_ptr<api::APluginConfig> config, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, config, level);
             };
 
 
+            /**
+             * @brief Set Property MAP Specialization
+             */
+            template<typename T1, typename T2>
+            void _setUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, GameObject entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, type, level);
+                    _setSubProperty("", *valueElem, value, entity, type, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, Engine &entity, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, type, level);
+                    _setSubProperty("", *valueElem, value, entity, type, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, safe_ptr<AComponent> &entity,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, level);
+                    _setSubProperty("", *valueElem, value, entity, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, safe_ptr<api::APluginConfig> &entity,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                for (auto &elem: *data)
+                {
+                    T1 key;
+                    auto keyElem = elem->begin();
+                    T2 value;
+                    auto valueElem = elem->begin() + 1;
+                    _setSubProperty("", *keyElem, key, entity, level);
+                    _setSubProperty("", *valueElem, value, entity, level);
+                    toSet.insert_or_assign(key, value);
+                }
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, safe_ptr<api::APluginConfig> config,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, config, level);
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, safe_ptr<AComponent> config,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, config, level);
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, GameObject config, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, config, type, level);
+            };
+
+            template<typename T1, typename T2>
+            void _setSubProperty(const std::string &propertyName,
+                                 const std::shared_ptr<myxmlpp::Node> &data,
+                                 std::unordered_map<T1, T2> &toSet, Engine &config, std::string type,
+                                 debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _setUMapProperty<T1, T2>(property, toSet, config, type, level);
+            };
+
+            /**
+ * @brief Extract an UNORDERED MAP property from the xml node
+ *
+ * @tparam T1 The type of the Key
+ * @tparam T2 The type of the Value
+ * @param propertyName The name of the property
+ * @param toSave The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T1, typename T2>
+            void save(const std::string &propertyName, std::unordered_map<T1, T2> &toSave, debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _saveUMapProperty<T1, T2>(property, toSave, level);
+            };
+            
+            /**
+ * @brief Set Property UNORDERED MAP Specialization
+ */
+            template<typename T1, typename T2>
+            void _saveUMapProperty(std::shared_ptr<myxmlpp::Node> &data,
+                                   std::unordered_map<T1, T2> &toSet,
+                                   debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                int i = 0;
+                int countToPop = 0;
+
+                std::vector<std::string> toPop;
+                std::vector<std::shared_ptr<myxmlpp::Node>> toKeep;
+                for (auto &elem: *data)
+                {
+                    if (i >= toSet.size()) {
+                        countToPop++;
+                        continue;
+                    }
+                    auto keyElem = elem->begin();
+                    auto valueElem = elem->begin() + 1;
+                    _saveSubProperty("", *keyElem, (toSet.begin() + i)->first, level);
+                    _saveSubProperty("", *valueElem, (toSet.begin() + i)->second, level);
+                }
+                toKeep.insert(toKeep.end(), data->begin(), data->begin() + i);
+                data->rmChildren();
+                for (auto &elem: toKeep)
+                    data->addChild(elem);
+            };
+
+            /**
+ * @brief Extract an UNORDERED MAP SUB-property from the xml node
+ *
+ * @tparam T1 The type of the Key
+ * @tparam T2 The type of the Value
+ * @param propertyName The name of the property
+ * @param data The node to search the sub-property in
+ * @param toSet The property to set
+ * @param level The level of the error if something goes wrong (not found or wrong value)
+ */
+            template<typename T1, typename T2>
+            void _saveSubProperty(const std::string &propertyName,
+                                  const std::shared_ptr<myxmlpp::Node> &data,
+                                  std::unordered_map<T1, T2> &toSet,
+                                  debug::Logger::severity level = debug::Logger::DEBUG)
+            {
+                std::shared_ptr<myxmlpp::Node> property = (!propertyName.empty())
+                                                          ? _findProperty(propertyName, data)
+                                                          : data;
+
+                if (property == nullptr)
+                    _onMissingPropertyExcept(level, propertyName);
+                _saveUMapProperty<T1, T2>(property, toSet, level);
+            };
 
 
+///////////////////////////// XML UMAP SETTERS END /////////////////////////////
 
 
+            
+
+
+        protected:
             /* ***********************************************
              * @group Find property utilities
              * ***********************************************/

--- a/include/polymorph/engine/config/XmlSerializableObject.hpp
+++ b/include/polymorph/engine/config/XmlSerializableObject.hpp
@@ -70,73 +70,20 @@ namespace polymorph::engine::config
         public:
 
             std::string getType() const;
-
-            template<typename T, typename T2 = void>
-            void set(const std::string &propertyName, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                if constexpr (std::is_enum<T>() && !CastHelper::is_builtin<T>)
-                    _setPrimitiveProperty(property, reinterpret_cast<int &>(toSet), level);
-                else if constexpr (!std::is_enum<T>() && !CastHelper::is_builtin<T>)
-                    _setPrimitiveProperty(property, toSet, level);
-                else if constexpr (CastHelper::is_builtin<T>)
-                    _setBuiltinProperty(property, toSet, level);
-            };
-
+            
             template<typename T>
-            void set(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                _setSerializableProperty<T>(property, toSet, level);
-            };
-
-            template<typename T>
-            void set(const std::string &propertyName, safe_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                if (_isFromConfig)
-                {
-                    _logger.log("Cannot set a Reference to object in a plugin config", debug::Logger::MAJOR);
-                    return;
+            void set(std::string property, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG) {
+                if (_isFromConfig) {
+                    this->XmlPropertyManager::set(property, toSet, _config, level);
+                } else {
+                    this->XmlPropertyManager::set(property, toSet, _component, level);
                 }
-
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                _setRefProperty<T>(property, toSet, level);
-            };
+            }
 
             template<typename T>
-            void save(const std::string &propertyName, safe_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                if (_isFromConfig)
-                {
-                    _logger.log("Cannot save a Reference to object in a plugin config", debug::Logger::MAJOR);
-                    return;
-                }
-                std::shared_ptr<myxmlpp::Node> property = _findProperty(propertyName);
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                static_assert(!CastHelper::is_map<T>);
-                _saveRefProperty<T>(property, toSet, level);
-            };
-
-            template<typename T>
-            void save(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                static_assert(!CastHelper::is_map<T>);
-                toSet->saveAll();
-            };
-
+            void save(std::string property, T &toSet, debug::Logger::severity level = debug::Logger::DEBUG) {
+                this->XmlPropertyManager::save(property, toSet, level);
+            }
         private:
 
             void _logMissingProperty(std::string type, std::string name, debug::Logger::severity level);
@@ -161,147 +108,7 @@ namespace polymorph::engine::config
             void _onMissingPropertyExcept(debug::Logger::severity level,
                                           std::string propertyName) override;
 
-            template<typename T, typename T2 = void>
-            void _setSerializableProperty(std::shared_ptr<myxmlpp::Node> &data,
-                                    std::shared_ptr<T> &toSet,
-                                    debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-
-                //TODO: rework with new XmlSeralizableObject
-                static_assert(!CastHelper::is_map<T>
-                              && !CastHelper::is_vector<T>
-                              && !CastHelper::is_safeptr<T>
-                              && !std::is_enum<T>());
-                if constexpr (CastHelper::is_builtin<T>)
-                    return std::make_shared<T>(data, *this);
-                else {
-                    auto t = data->findAttribute("subtype")->getValue();
-                    try {
-                        if (_isFromConfig)
-                            toSet = std::dynamic_pointer_cast<T>(_component->Plugin.tryCreateComponentObject(t, data, _component));
-                        else
-                            toSet = std::dynamic_pointer_cast<T>(_config->Plugin.tryCreateConfigObject(t, data, _config));
-                    }  catch (debug::ExceptionLogger &e) {
-                        if (level == debug::Logger::MAJOR)
-                            e.what();
-                    }
-                }
-            };
-
-
-            template<typename T>
-            void _setSubProperty(const std::string &propertyName,
-                                 const std::shared_ptr<myxmlpp::Node> &data,
-                                 std::shared_ptr<T> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    return;
-                _setSerializableProperty<T>(property, toSet, level);
-            };
-
-
-
-            template<typename T>
-            void _saveSubProperty(const std::string &propertyName,
-                                  const std::shared_ptr<myxmlpp::Node> &data,
-                                  std::shared_ptr<T> &toSet,
-                                  debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::shared_ptr<myxmlpp::Node> property = (propertyName != "")
-                                                          ? _findProperty(propertyName, data)
-                                                          : data;
-
-                if (property == nullptr)
-                    _onMissingPropertyExcept(level, propertyName);
-                toSet->saveAll();
-            };
-
-            template<typename T, typename T2 = void>
-            void _setRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
-                                 safe_ptr<T> &toSet,
-                                 debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::string id;
-                std::string name = refProp->findAttribute("name")->getValue();
-                GameObject gameObject;
-
-                if (!_setPropertyFromAttr(id, refProp, level))
-                    return;
-                if (_component && (_component->gameObject->getPrefabId() == id || _component->gameObject->getId() == id))
-                    gameObject = _component->gameObject;
-                if (!gameObject && _component->gameObject->wasPrefab())
-                    gameObject = _component->gameObject->findByPrefabId(id);
-                else if (!gameObject)
-                    gameObject = _component->Scene.findById(id);
-                if (gameObject)
-                    toSet = gameObject->getComponent<T>();
-                if (!toSet)
-                    _onWrongValueExcept(level, name, id);
-            };
-
-            template<typename T2 = void>
-            void _setRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
-                                 GameObject &toSet, debug::Logger::severity level)
-            {
-                std::string id;
-                std::string name = refProp->findAttribute("name")->getValue();
-
-                if (!_setPropertyFromAttr(id, refProp, level))
-                    return;
-                if (_component && (_component->gameObject->getPrefabId() == id || _component->gameObject->getId() == id))
-                    toSet = _component->gameObject;
-                if (!toSet && _component->gameObject)
-                    toSet = _component->gameObject->findByPrefabId(id);
-                if (!toSet)
-                    toSet = _component->Scene.findById(id);
-                if (!toSet)
-                    _onWrongValueExcept(level, name, id);
-            };
-
-            template<typename T, typename T2 = void>
-            void _saveRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
-                                  safe_ptr<T> &toSet,
-                                  debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                std::string id = (toSet) ? toSet->gameObject->getId() : "";
-
-                if (!_savePropertyFromAttr(id, refProp, level))
-                    return;
-            };
-
-            template<typename T2 = void>
-            void _saveRefProperty(std::shared_ptr<myxmlpp::Node> &refProp,
-                                  GameObject &toSet, debug::Logger::severity level)
-            {
-                std::string id = (toSet) ? toSet->getId() : "";
-
-                if (!_savePropertyFromAttr(id, refProp, level))
-                    return;
-            };
-
-            /**
-             * @brief Set Property BUILTIN Specialization
-             */
-            template<typename T, typename T2 = void>
-            void _setBuiltinProperty(std::shared_ptr<myxmlpp::Node> &data, T &toSet,
-                                       debug::Logger::severity level = debug::Logger::DEBUG)
-            {
-                static_assert(!CastHelper::is_map<T>
-                              && !CastHelper::is_vector<T>
-                              && !CastHelper::is_safeptr<T>
-                              && !std::is_enum<T>()
-                              && CastHelper::is_builtin<T>);
-                if (_isFromConfig)
-                    toSet = T(_config, data);
-                else
-                    toSet = T(_component, data);
-            };
-//////////////////////--------------------------/////////////////////////
+         //////////////////////--------------------------/////////////////////////
 
     };
 

--- a/include/polymorph/engine/core.hpp
+++ b/include/polymorph/engine/core.hpp
@@ -12,8 +12,10 @@
 #include "polymorph/engine/core/Scene.hpp"
 
 #include "polymorph/engine/core/entity/Entity.hpp"
+#include "polymorph/engine/core/entity/Entity_templated.hpp"
 
 #include "polymorph/engine/core/component/AComponent.hpp"
+#include "polymorph/engine/core/component/AComponent_templated.hpp"
 #include "polymorph/engine/core/component/TransformComponent.hpp"
 
 #include "polymorph/engine/time/Time.hpp"

--- a/include/polymorph/engine/core/Engine.hpp
+++ b/include/polymorph/engine/core/Engine.hpp
@@ -20,7 +20,6 @@
 #include "polymorph/engine/api/plugin/PluginManager.hpp"
 #include "polymorph/engine/api/SceneManager.hpp"
 #include "polymorph/engine/time/Time.hpp"
-#include "polymorph/engine/config/XmlComponent.hpp"
 #include "polymorph/engine/config/XmlEngine.hpp"
 
 namespace polymorph::engine

--- a/include/polymorph/engine/core/component/AComponent.hpp
+++ b/include/polymorph/engine/core/component/AComponent.hpp
@@ -299,46 +299,11 @@ namespace polymorph::engine
             void saveProperty(std::string propertyName, T &toSave);
 
 
-            /**
-             * @brief Saves a property in the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The value of the property
-             */
-            template<typename T>
-            void saveProperty(std::string propertyName, std::shared_ptr<T> &toSave);
-
-            /**
-             * @brief Saves a property in the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The value of the property
-             */
-            template<typename T>
-            void saveProperty(std::string propertyName, safe_ptr<T> &toSave);
-
             std::shared_ptr<myxmlpp::Node> getNode();
             
             std::shared_ptr<config::XmlComponent> getConfig();
 
         protected:
-            /**
-             * @brief Sets a property from the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The property to set
-             */
-            template<typename T>
-            void _setProperty(const std::string &propertyName, std::shared_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG);
-
-            /**
-             * @brief Sets a property from the Xml data by its name
-             * @param name The name of the property
-             * @tparam T The type of the property
-             * @param value The property to set
-             */
-            template<typename T>
-            void _setProperty(const std::string &propertyName, safe_ptr<T> &toSet, debug::Logger::severity level = debug::Logger::DEBUG);
 
             /**
              * @brief Sets a property from the Xml data by its name

--- a/include/polymorph/engine/core/component/AComponent_templated.hpp
+++ b/include/polymorph/engine/core/component/AComponent_templated.hpp
@@ -72,39 +72,7 @@ namespace polymorph::engine
     void
     polymorph::engine::AComponent::saveProperty(std::string propertyName, T &toSave)
     {
-        _xmlConfig->XmlPropertyManager::save(propertyName, toSave);
-    }
-
-    template<typename T>
-    void polymorph::engine::AComponent::saveProperty(std::string propertyName,
-                                                     std::shared_ptr<T> &toSave)
-    {
         _xmlConfig->save(propertyName, toSave);
-    }
-
-    template<typename T>
-    void polymorph::engine::AComponent::saveProperty(std::string propertyName,
-                                                     polymorph::engine::safe_ptr<T> &toSave)
-    {
-        _xmlConfig->save(propertyName, toSave);
-    }
-
-    template<typename T>
-    void
-    polymorph::engine::AComponent::_setProperty(const std::string &propertyName,
-                                                std::shared_ptr<T> &toSet,
-                                                polymorph::engine::debug::Logger::severity level)
-    {
-        _xmlConfig->set(propertyName, toSet, level);
-    }
-
-    template<typename T>
-    void
-    polymorph::engine::AComponent::_setProperty(const std::string &propertyName,
-                                                polymorph::engine::safe_ptr<T> &toSet,
-                                                polymorph::engine::debug::Logger::severity level)
-    {
-        _xmlConfig->set(propertyName, toSet, level);
     }
 
     template<typename T>

--- a/include/polymorph/engine/core/entity/Entity_templated.hpp
+++ b/include/polymorph/engine/core/entity/Entity_templated.hpp
@@ -10,6 +10,7 @@
 #include "polymorph/engine/core/entity/Entity.hpp"
 #include "polymorph/engine/core/Engine.hpp"
 #include "polymorph/engine/core/component/AComponent.hpp"
+#include "polymorph/engine/config/XmlComponent.hpp"
 
 namespace polymorph::engine
 {
@@ -19,7 +20,7 @@ namespace polymorph::engine
         for (auto &components: _components)
             for (auto &component: components.second)
             {
-                auto &casted = std::dynamic_pointer_cast<T>(component);
+                auto casted = std::dynamic_pointer_cast<T>(component);
                 if (casted)
                     return safe_ptr<T>(casted);
             }

--- a/include/polymorph/engine/core/entity/Entity_templated.hpp
+++ b/include/polymorph/engine/core/entity/Entity_templated.hpp
@@ -19,7 +19,7 @@ namespace polymorph::engine
         for (auto &components: _components)
             for (auto &component: components.second)
             {
-                auto casted = std::dynamic_pointer_cast<T>(component);
+                auto &casted = std::dynamic_pointer_cast<T>(component);
                 if (casted)
                     return safe_ptr<T>(casted);
             }
@@ -46,7 +46,7 @@ namespace polymorph::engine
         std::string type = T::type;
 
         if (componentExist(type))
-            return;
+            return getComponent<T>();
         //TODO : throw ?
         std::shared_ptr<AComponent> newComponent;
         std::shared_ptr<myxmlpp::Node> config = Game.getDefaultConfig(type);

--- a/include/polymorph/engine/debug/exception/config/WrongValueException.hpp
+++ b/include/polymorph/engine/debug/exception/config/WrongValueException.hpp
@@ -22,7 +22,7 @@ namespace polymorph::engine::debug
             WrongValueException(std::string entity, std::string component, std::string property, std::string value, std::string object = "", Logger::severity level = Logger::MAJOR);
             WrongValueException(std::string object, std::string property, std::string value, Logger::severity level = Logger::MAJOR);
 
-            ~WrongValueException();
+            ~WrongValueException() override = default;
 
 //////////////////////--------------------------/////////////////////////
 

--- a/src/src/api/plugin/APluginConfig.cpp
+++ b/src/src/api/plugin/APluginConfig.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "polymorph/engine/api/plugin/APluginConfig.hpp"
+#include "polymorph/engine/config/XmlPluginConfig.hpp"
 #include "polymorph/engine/core/Engine.hpp"
 #include "polymorph/engine/debug/exception/config/MissingFileException.hpp"
 #include "polymorph/engine/debug/exception/CoreException.hpp"

--- a/src/src/config/XmlComponent.cpp
+++ b/src/src/config/XmlComponent.cpp
@@ -6,12 +6,12 @@
 */
 
 #include "polymorph/engine/debug/Logger.hpp"
-#include "polymorph/engine/config/XmlPropertyManager.hpp"
 #include "polymorph/engine/config/XmlComponent.hpp"
 #include "polymorph/engine/config/XmlEntity.hpp"
 #include "polymorph/engine/debug/exception/config/MissingComponentTypeException.hpp"
 #include "polymorph/engine/debug/exception/config/MissingPropertyException.hpp"
 #include "polymorph/engine/debug/exception/config/WrongValueException.hpp"
+#include "polymorph/engine/debug/exception/config/MissingValueException.hpp"
 
 namespace polymorph::engine::config
 {

--- a/src/src/core/Engine.cpp
+++ b/src/src/core/Engine.cpp
@@ -9,6 +9,8 @@
 
 #include "polymorph/engine/core/Engine.hpp"
 #include "polymorph/engine/config/XmlEntity.hpp"
+#include "polymorph/engine/config/XmlComponent.hpp"
+#include "polymorph/engine/debug/exception/ConfigurationException.hpp"
 
 polymorph::engine::Engine::Engine(std::string projectName, std::string projectPath, std::string pluginsPath)
         : _projectName(std::move(projectName)), _projectPath(std::move(projectPath)), _pluginsPath(std::move(pluginsPath)),

--- a/src/src/core/component/TransformComponent.cpp
+++ b/src/src/core/component/TransformComponent.cpp
@@ -7,6 +7,7 @@
 
 
 #include "polymorph/engine/core/component/TransformComponent.hpp"
+#include "polymorph/engine/core/component/AComponent_templated.hpp"
 
 polymorph::engine::TransformComponent::TransformComponent(std::shared_ptr<myxmlpp::Node> data, polymorph::engine::GameObject gameObject)
     : AComponent(data, gameObject), _smoothTimer(gameObject, 0)

--- a/src/src/core/entity/Entity.cpp
+++ b/src/src/core/entity/Entity.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "polymorph/engine/core/entity/Entity.hpp"
+#include "polymorph/engine/core/entity/Entity_templated.hpp"
 #include "polymorph/engine/core/Engine.hpp"
 #include "polymorph/engine/core/Scene.hpp"
 #include "polymorph/engine/core/component/TransformComponent.hpp"

--- a/src/src/types/vector/Vector3.cpp
+++ b/src/src/types/vector/Vector3.cpp
@@ -281,7 +281,7 @@ void polymorph::engine::Vector3::build()
 
 void polymorph::engine::Vector3::saveAll()
 {
-    _setProperty("x", x);
-    _setProperty("y", y);
-    _setProperty("z", z);
+    saveProperty("x", x);
+    saveProperty("y", y);
+    saveProperty("z", z);
 }


### PR DESCRIPTION
# Description

Reworked so that the XmlPropertyManager class now contains all set/save logic  for any type of properties whatever their origin.
Fixed some compilation issues coming from missing includes.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have updated the documentation
- [ ] I have updated the README.md
